### PR TITLE
Bugfix on missing requirement

### DIFF
--- a/fetch_feed.rb
+++ b/fetch_feed.rb
@@ -1,6 +1,7 @@
 require 'optparse'
 require 'oauth'
 require 'net/http'
+require 'date'
 
 FEEDS_API_HOST = 'feeds.api.7digital.com'
 FEEDS_API_PATH = '/1.2/feed/'


### PR DESCRIPTION
Without the `require date` on the file header the script could not be executed on most recent versions of ruby
